### PR TITLE
Fix repaint not working.

### DIFF
--- a/src/ui/membrane_ui.clj
+++ b/src/ui/membrane_ui.clj
@@ -83,8 +83,8 @@
         (Thread/sleep 50)
         (next-frame! framenum total-pages)
         ; see if we can force repaint
-        (if-let [w (resolve 'w)]
-          ((:membrane.skia/repaint w)))
+        (if-let [w (resolve `w)]
+          ((:membrane.skia/repaint @w)))
         (recur (inc framenum) total-pages)))))
 
 


### PR DESCRIPTION
There are two subtle issues:

1) `resolve` returns a var which doesn't respond to keyword lookups. 

This was fixed by derefing `w`.

2) `resolve` tries to find the var in the `*ns*` namespace.

Since animate is run in a future, it might not have the right thread-local value for `*ns*`. To fix, I just fully qualify `w` with a backtick.